### PR TITLE
AquaSKKでURL指定ができなくなっていたためREADMEを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@
 多分読み込めるハズ……  
 
 - SKK日本語入力FEP (Windows)
-- AquaSKK (Mac)
+- ~~AquaSKK (Mac)~~
 - FlickSKK (iPhone)
 
 で確認。
+
+※AquaSKKは辞書の「場所」にURLが指定できなくなっていたので、このリポジトリをCloneしてローカルのファイルを指定して下さい。
 
 ## 辞書の内容
 


### PR DESCRIPTION
## この変更はなぜ必要でしたか?

AquaSKKでURL指定ができなくなっていたため。

## この問題にどうやって対処しましたか?

READMEの説明文を修正。

## この変更によって影響を受けるものは何ですか?

特になし。

## 関連するチケット，issueがあれば記載して下さい

特になし。